### PR TITLE
Fixed thumbnail inconsistency 

### DIFF
--- a/k4l-video-trimmer/build.gradle
+++ b/k4l-video-trimmer/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     androidTestImplementation "com.android.support:support-annotations:${versions.supportLib}"
     testImplementation "junit:junit:${versions.junit}"
     implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation "com.jakewharton.threetenabp:threetenabp:${versions.threetenabp}"
     implementation "com.android.support:appcompat-v7:${versions.supportLib}"
     implementation "com.googlecode.mp4parser:isoparser:${versions.isoparser}"
     implementation "com.google.android.exoplayer:exoplayer:${versions.exoplayer}"

--- a/k4l-video-trimmer/build.gradle
+++ b/k4l-video-trimmer/build.gradle
@@ -22,12 +22,12 @@ android {
 }
 
 dependencies {
-    androidTestCompile "com.android.support.test.espresso:espresso-core:${versions.espresso}"
-    androidTestCompile "com.android.support.test:runner:${versions.testRunner}"
-    androidTestCompile "com.android.support:support-annotations:${versions.supportLib}"
-    testCompile "junit:junit:${versions.junit}"
-    compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile "com.android.support:appcompat-v7:${versions.supportLib}"
-    compile "com.googlecode.mp4parser:isoparser:${versions.isoparser}"
-    compile "com.google.android.exoplayer:exoplayer:${versions.exoplayer}"
+    androidTestImplementation "com.android.support.test.espresso:espresso-core:${versions.espresso}"
+    androidTestImplementation "com.android.support.test:runner:${versions.testRunner}"
+    androidTestImplementation "com.android.support:support-annotations:${versions.supportLib}"
+    testImplementation "junit:junit:${versions.junit}"
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
+    implementation "com.android.support:appcompat-v7:${versions.supportLib}"
+    implementation "com.googlecode.mp4parser:isoparser:${versions.isoparser}"
+    implementation "com.google.android.exoplayer:exoplayer:${versions.exoplayer}"
 }

--- a/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/K4LVideoTrimmer.java
+++ b/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/K4LVideoTrimmer.java
@@ -24,6 +24,7 @@
 package life.knowledge4.videotrimmer;
 
 import android.content.Context;
+import android.graphics.Bitmap;
 import android.media.MediaMetadataRetriever;
 import android.media.MediaPlayer;
 import android.net.Uri;
@@ -45,7 +46,11 @@ import android.widget.RelativeLayout;
 import android.widget.SeekBar;
 import android.widget.VideoView;
 
+import org.threeten.bp.LocalDateTime;
+
 import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
@@ -354,7 +359,7 @@ public class K4LVideoTrimmer extends FrameLayout {
     mPlayView.setVisibility(View.VISIBLE);
 
     mThumbnailPositionInMillis = mTimeLineView.getThumbnailMillis(mDuration * seekBar.getProgress() / 1000);
-    mVideoView.seekTo(mDuration * seekBar.getProgress() / 1000);
+    mVideoView.seekTo(mThumbnailPositionInMillis);
     notifyProgressUpdate(false);
   }
 
@@ -423,6 +428,22 @@ public class K4LVideoTrimmer extends FrameLayout {
     setProgressBarPosition(mStartPosition);
 
     mTimeVideo = mEndPosition - mStartPosition;
+  }
+
+  public Uri getBitmapUri() {
+    Bitmap thumbnail = mTimeLineView.getBitmapFromMillis(mThumbnailPositionInMillis);
+    File outputDir = getContext().getCacheDir();
+    Long timeStamp = LocalDateTime.now().toEpochSecond(org.threeten.bp.ZoneOffset.UTC);
+    try {
+      File outputFile = File.createTempFile("IMG_" + timeStamp, ".jpg", outputDir);
+      FileOutputStream out = new FileOutputStream(outputFile);
+      thumbnail.compress(Bitmap.CompressFormat.JPEG, 100, out);
+      return Uri.parse(outputFile.getPath());
+    } catch (IOException e1) {
+      e1.printStackTrace();
+    }
+
+    return null;
   }
 
   private void onStopSeekThumbs() {

--- a/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/K4LVideoTrimmer.java
+++ b/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/K4LVideoTrimmer.java
@@ -354,7 +354,7 @@ public class K4LVideoTrimmer extends FrameLayout {
     mPlayView.setVisibility(View.VISIBLE);
 
     mThumbnailPositionInMillis = mTimeLineView.getThumbnailMillis(mDuration * seekBar.getProgress() / 1000);
-    mVideoView.seekTo(mThumbnailPositionInMillis);
+    mVideoView.seekTo(mDuration * seekBar.getProgress() / 1000);
     notifyProgressUpdate(false);
   }
 

--- a/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/K4LVideoTrimmer.java
+++ b/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/K4LVideoTrimmer.java
@@ -355,7 +355,7 @@ public class K4LVideoTrimmer extends FrameLayout {
 
     mThumbnailPositionInMillis = mTimeLineView.getThumbnailMillis(mDuration * seekBar.getProgress() / 1000);
     mVideoView.seekTo(mThumbnailPositionInMillis);
-    notifyProgressUpdate(true);
+    notifyProgressUpdate(false);
   }
 
   private void onVideoPrepared(@NonNull MediaPlayer mp) {

--- a/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/K4LVideoTrimmer.java
+++ b/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/K4LVideoTrimmer.java
@@ -25,17 +25,14 @@ package life.knowledge4.videotrimmer;
 
 import android.content.Context;
 import android.graphics.Bitmap;
-import android.graphics.Canvas;
 import android.media.MediaMetadataRetriever;
 import android.media.MediaPlayer;
 import android.net.Uri;
-import android.os.Build;
 import android.os.Environment;
 import android.os.Handler;
 import android.os.Message;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
-import android.support.annotation.RequiresApi;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.view.GestureDetector;
@@ -57,7 +54,6 @@ import java.io.IOException;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Stream;
 
 import life.knowledge4.videotrimmer.interfaces.OnK4LVideoListener;
 import life.knowledge4.videotrimmer.interfaces.OnProgressVideoListener;
@@ -371,8 +367,8 @@ public class K4LVideoTrimmer extends FrameLayout {
     notifyProgressUpdate(false);
   }
 
-  private void setThumbnailInMillis(@NonNull int progress) {
-    mThumbnailPositionInMillis = mTimeLineView.getThumbnailMillis(mDuration * progress / 1000);
+  private void setThumbnailInMillis(int progress) {
+    mThumbnailPositionInMillis = mDuration * progress / 1000;
     Bitmap thumbnail = mTimeLineView.getBitmapFromMillis(mThumbnailPositionInMillis);
     if (thumbnail != null) {
       mVideoThumbnailView.setImageBitmap(thumbnail);
@@ -446,7 +442,8 @@ public class K4LVideoTrimmer extends FrameLayout {
     mTimeVideo = mEndPosition - mStartPosition;
   }
 
-  public String getBitmapString() {
+  @Nullable
+  public String getBitmapPath() {
     Bitmap thumbnail = mTimeLineView.getBitmapFromMillis(mThumbnailPositionInMillis);
     File outputDir = getContext().getCacheDir();
     Long timeStamp = LocalDateTime.now().toEpochSecond(org.threeten.bp.ZoneOffset.UTC);
@@ -455,10 +452,9 @@ public class K4LVideoTrimmer extends FrameLayout {
       FileOutputStream out = new FileOutputStream(outputFile);
       thumbnail.compress(Bitmap.CompressFormat.JPEG, 100, out);
       return outputFile.getPath();
-    } catch (IOException e1) {
-      e1.printStackTrace();
+    } catch (IOException e) {
+      e.printStackTrace();
     }
-
     return null;
   }
 

--- a/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/K4LVideoTrimmer.java
+++ b/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/K4LVideoTrimmer.java
@@ -353,10 +353,9 @@ public class K4LVideoTrimmer extends FrameLayout {
     mVideoView.pause();
     mPlayView.setVisibility(View.VISIBLE);
 
-
     mThumbnailPositionInMillis = mTimeLineView.getThumbnailMillis(mDuration * seekBar.getProgress() / 1000);
     mVideoView.seekTo(mThumbnailPositionInMillis);
-    notifyProgressUpdate(false);
+    notifyProgressUpdate(true);
   }
 
   private void onVideoPrepared(@NonNull MediaPlayer mp) {
@@ -478,7 +477,6 @@ public class K4LVideoTrimmer extends FrameLayout {
   }
 
   /**
-   *
    * @return Selected thumbnail position in millis
    */
   @Nullable

--- a/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/K4LVideoTrimmer.java
+++ b/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/K4LVideoTrimmer.java
@@ -353,7 +353,8 @@ public class K4LVideoTrimmer extends FrameLayout {
     mVideoView.pause();
     mPlayView.setVisibility(View.VISIBLE);
 
-    mThumbnailPositionInMillis = (int) ((mDuration * seekBar.getProgress()) / 1000L);
+
+    mThumbnailPositionInMillis = mTimeLineView.getThumbnailMillis(mDuration * seekBar.getProgress() / 1000);
     mVideoView.seekTo(mThumbnailPositionInMillis);
     notifyProgressUpdate(false);
   }

--- a/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/K4LVideoTrimmer.java
+++ b/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/K4LVideoTrimmer.java
@@ -54,6 +54,7 @@ import java.io.IOException;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Stream;
 
 import life.knowledge4.videotrimmer.interfaces.OnK4LVideoListener;
 import life.knowledge4.videotrimmer.interfaces.OnProgressVideoListener;
@@ -430,7 +431,7 @@ public class K4LVideoTrimmer extends FrameLayout {
     mTimeVideo = mEndPosition - mStartPosition;
   }
 
-  public Uri getBitmapUri() {
+  public String getBitmapString() {
     Bitmap thumbnail = mTimeLineView.getBitmapFromMillis(mThumbnailPositionInMillis);
     File outputDir = getContext().getCacheDir();
     Long timeStamp = LocalDateTime.now().toEpochSecond(org.threeten.bp.ZoneOffset.UTC);
@@ -438,7 +439,7 @@ public class K4LVideoTrimmer extends FrameLayout {
       File outputFile = File.createTempFile("IMG_" + timeStamp, ".jpg", outputDir);
       FileOutputStream out = new FileOutputStream(outputFile);
       thumbnail.compress(Bitmap.CompressFormat.JPEG, 100, out);
-      return Uri.parse(outputFile.getPath());
+      return outputFile.getPath();
     } catch (IOException e1) {
       e1.printStackTrace();
     }

--- a/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/utils/ThumbnailData.java
+++ b/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/utils/ThumbnailData.java
@@ -5,10 +5,20 @@ import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 public class ThumbnailData {
+  @Nullable
   private Bitmap thumbnail;
+  @NonNull
   private Bitmap thumbnailFullSize;
+  @NonNull
   private Integer time;
 
+  public ThumbnailData(@Nullable Bitmap thumbnail, @NonNull Bitmap thumbnailFullSize, @NonNull Integer time) {
+    this.thumbnail = thumbnail;
+    this.thumbnailFullSize = thumbnailFullSize;
+    this.time = time;
+  }
+
+  @Nullable
   public Bitmap getThumbnail() {
     return thumbnail;
   }
@@ -17,6 +27,7 @@ public class ThumbnailData {
     this.thumbnail = thumbnail;
   }
 
+  @NonNull
   public Bitmap getThumbnailFullSize() {
     return thumbnailFullSize;
   }
@@ -25,17 +36,13 @@ public class ThumbnailData {
     this.thumbnailFullSize = thumbnailFullSize;
   }
 
+
+  @NonNull
   public Integer getTime() {
     return time;
   }
 
   public void setTime(@NonNull Integer time) {
-    this.time = time;
-  }
-
-  public ThumbnailData(@Nullable Bitmap thumbnail, @NonNull Bitmap thumbnailFullSize, @NonNull Integer time) {
-    this.thumbnail = thumbnail;
-    this.thumbnailFullSize = thumbnailFullSize;
     this.time = time;
   }
 }

--- a/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/utils/ThumbnailData.java
+++ b/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/utils/ThumbnailData.java
@@ -1,0 +1,41 @@
+package life.knowledge4.videotrimmer.utils;
+
+import android.graphics.Bitmap;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+
+public class ThumbnailData {
+  private Bitmap thumbnail;
+  private Bitmap thumbnailFullSize;
+  private Integer time;
+
+  public Bitmap getThumbnail() {
+    return thumbnail;
+  }
+
+  public void setThumbnail(@Nullable Bitmap thumbnail) {
+    this.thumbnail = thumbnail;
+  }
+
+  public Bitmap getThumbnailFullSize() {
+    return thumbnailFullSize;
+  }
+
+  public void setThumbnailFullSize(@NonNull Bitmap thumbnailFullSize) {
+    this.thumbnailFullSize = thumbnailFullSize;
+  }
+
+  public Integer getTime() {
+    return time;
+  }
+
+  public void setTime(@NonNull Integer time) {
+    this.time = time;
+  }
+
+  public ThumbnailData(@Nullable Bitmap thumbnail, @NonNull Bitmap thumbnailFullSize, @NonNull Integer time) {
+    this.thumbnail = thumbnail;
+    this.thumbnailFullSize = thumbnailFullSize;
+    this.time = time;
+  }
+}

--- a/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/utils/ThumbnailData.java
+++ b/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/utils/ThumbnailData.java
@@ -36,7 +36,6 @@ public class ThumbnailData {
     this.thumbnailFullSize = thumbnailFullSize;
   }
 
-
   @NonNull
   public Integer getTime() {
     return time;

--- a/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/view/TimeLineView.java
+++ b/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/view/TimeLineView.java
@@ -163,8 +163,9 @@ public class TimeLineView extends View {
     if (mBitmapList != null) {
       Integer last = mBitmapList.get(0).first;
       for (int i = 1; i < mBitmapList.size(); i++) {
-        if (time - mBitmapList.get(i).first < 0) {
-          last = mBitmapList.get(i - 1).first;
+        if (time - mBitmapList.get(i).first > 0) {
+          last = mBitmapList.get(i).first;
+        }else {
           break;
         }
       }

--- a/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/view/TimeLineView.java
+++ b/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/view/TimeLineView.java
@@ -105,7 +105,7 @@ public class TimeLineView extends View {
                                      final long interval = videoLengthInMs / numThumbs;
 
                                      for (int i = 0; i < numThumbs; ++i) {
-                                       Bitmap bitmap = mediaMetadataRetriever.getFrameAtIndex(i);
+                                       Bitmap bitmap = mediaMetadataRetriever.getFrameAtTime(i * interval, MediaMetadataRetriever.OPTION_CLOSEST_SYNC);
                                        // TODO: bitmap might be null here, hence throwing NullPointerException. You were right
                                        try {
                                          bitmap = Bitmap.createScaledBitmap(bitmap, thumbWidth, thumbHeight, false);
@@ -163,7 +163,7 @@ public class TimeLineView extends View {
       Integer last = mBitmapList.get(0).first;
       for (int i = 1; i < mBitmapList.size(); i++) {
         if (time - mBitmapList.get(i).first >= 0) {
-          last = i;
+          last = mBitmapList.get(i).first;
         }else {
           break;
         }
@@ -171,6 +171,22 @@ public class TimeLineView extends View {
       return last;
     }
     return 0;
+  }
+
+  @Nullable
+  public Bitmap getBitmapFromMillis(@NonNull Integer time){
+    if (mBitmapList != null) {
+      Bitmap thumbnail = mBitmapList.get(0).second;
+      for (int i = 1; i < mBitmapList.size(); i++) {
+        if (time - mBitmapList.get(i).first >= 0) {
+          thumbnail = mBitmapList.get(i).second;
+        }else {
+          break;
+        }
+      }
+      return thumbnail;
+    }
+    return null;
   }
 
   public void setVideo(@NonNull Uri data) {

--- a/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/view/TimeLineView.java
+++ b/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/view/TimeLineView.java
@@ -106,7 +106,7 @@ public class TimeLineView extends View {
                                      final long interval = videoLengthInMs / numThumbs;
 
                                      for (int i = 0; i < numThumbs; ++i) {
-                                       Bitmap bitmap = mediaMetadataRetriever.getFrameAtTime(i * interval, MediaMetadataRetriever.OPTION_CLOSEST_SYNC);
+                                       Bitmap bitmap = mediaMetadataRetriever.getFrameAtTime(i * interval, MediaMetadataRetriever.OPTION_CLOSEST);
                                        // TODO: bitmap might be null here, hence throwing NullPointerException. You were right
                                        try {
                                          bitmap = Bitmap.createScaledBitmap(bitmap, thumbWidth, thumbHeight, false);

--- a/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/view/TimeLineView.java
+++ b/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/view/TimeLineView.java
@@ -163,7 +163,7 @@ public class TimeLineView extends View {
     if (mBitmapList != null) {
       Integer last = mBitmapList.get(0).first;
       for (int i = 1; i < mBitmapList.size(); i++) {
-        if (time - mBitmapList.get(i).first > 0) {
+        if (time - mBitmapList.get(i).first >= 0) {
           last = mBitmapList.get(i).first;
         }else {
           break;
@@ -171,7 +171,7 @@ public class TimeLineView extends View {
       }
       return last;
     }
-    return null;
+    return 0;
   }
 
   public void setVideo(@NonNull Uri data) {

--- a/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/view/TimeLineView.java
+++ b/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/view/TimeLineView.java
@@ -159,25 +159,10 @@ public class TimeLineView extends View {
     }
   }
 
-  @Nullable
-  public Integer getThumbnailMillis(@NonNull Integer time) {
-    if (mBitmapList != null) {
-      Integer last = mBitmapList.get(0).getTime();
-      for (int i = 1; i < mBitmapList.size(); i++) {
-        if (time - mBitmapList.get(i).getTime() >= 0) {
-          last = mBitmapList.get(i).getTime();
-        } else {
-          break;
-        }
-      }
-      return last;
-    }
-    return 0;
-  }
-
+  // Given a time in millis thus function returns the bitmap associated with the interval that time is in
   @Nullable
   public Bitmap getBitmapFromMillis(@NonNull Integer time) {
-    if (mBitmapList != null) {
+    if (mBitmapList != null && mBitmapList.size() > 0) {
       Bitmap thumbnail = mBitmapList.get(0).getThumbnailFullSize();
       for (int i = 1; i < mBitmapList.size(); i++) {
         if (time - mBitmapList.get(i).getTime() >= 0) {

--- a/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/view/TimeLineView.java
+++ b/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/view/TimeLineView.java
@@ -105,7 +105,7 @@ public class TimeLineView extends View {
                                      final long interval = videoLengthInMs / numThumbs;
 
                                      for (int i = 0; i < numThumbs; ++i) {
-                                       Bitmap bitmap = mediaMetadataRetriever.getFrameAtTime(i * interval, MediaMetadataRetriever.OPTION_CLOSEST);
+                                       Bitmap bitmap = mediaMetadataRetriever.getFrameAtIndex(i);
                                        // TODO: bitmap might be null here, hence throwing NullPointerException. You were right
                                        try {
                                          bitmap = Bitmap.createScaledBitmap(bitmap, thumbWidth, thumbHeight, false);
@@ -163,7 +163,7 @@ public class TimeLineView extends View {
       Integer last = mBitmapList.get(0).first;
       for (int i = 1; i < mBitmapList.size(); i++) {
         if (time - mBitmapList.get(i).first >= 0) {
-          last = mBitmapList.get(i).first;
+          last = i;
         }else {
           break;
         }

--- a/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/view/TimeLineView.java
+++ b/k4l-video-trimmer/src/main/java/life/knowledge4/videotrimmer/view/TimeLineView.java
@@ -94,7 +94,6 @@ public class TimeLineView extends View {
 
                                      // Retrieve media data
                                      Integer videoLengthInMillis = Integer.parseInt(mediaMetadataRetriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION));
-
                                      long videoLengthInMs = videoLengthInMillis * 1000;
 
                                      // Set thumbnail properties (Thumbs are squares)

--- a/k4l-video-trimmer/src/main/res/layout/view_time_line.xml
+++ b/k4l-video-trimmer/src/main/res/layout/view_time_line.xml
@@ -18,6 +18,14 @@
             android:layout_centerInParent="true"
             />
 
+        <ImageView
+            android:id="@+id/video_thumbnail"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:layout_centerInParent="true"
+            android:visibility="invisible"
+            />
+
     </RelativeLayout>
 
     <RelativeLayout

--- a/sample-app/build.gradle
+++ b/sample-app/build.gradle
@@ -30,12 +30,12 @@ repositories{
 }
 
 dependencies {
-    compile fileTree(dir: 'libs', include: ['*.jar'])
+    implementation fileTree(dir: 'libs', include: ['*.jar'])
     //compile 'life.knowledge4:k4l-video-trimmer:0.1-SNAPSHOT'
-    compile project(':k4l-video-trimmer')
-    compile "com.android.support:appcompat-v7:${versions.supportLib}"
-    testCompile "junit:junit:${versions.junit}"
-    androidTestCompile "com.android.support.test.espresso:espresso-core:${versions.espresso}"
-    androidTestCompile "com.android.support.test:runner:${versions.testRunner}"
-    androidTestCompile "com.android.support:support-annotations:${versions.supportLib}"
+    implementation project(':k4l-video-trimmer')
+    implementation "com.android.support:appcompat-v7:${versions.supportLib}"
+    testImplementation "junit:junit:${versions.junit}"
+    androidTestImplementation "com.android.support.test.espresso:espresso-core:${versions.espresso}"
+    androidTestImplementation "com.android.support.test:runner:${versions.testRunner}"
+    androidTestImplementation "com.android.support:support-annotations:${versions.supportLib}"
 }

--- a/versions.gradle
+++ b/versions.gradle
@@ -10,4 +10,5 @@ ext.versions = [
         publishVersionCode: 25,
         supportLib        : '28.0.0',
         testRunner        : '0.5',
+        threetenabp       : '1.1.1',
 ]

--- a/versions.gradle
+++ b/versions.gradle
@@ -1,13 +1,13 @@
 ext.versions = [
-        buildTools        : '26.0.2',
-        compileSdk        : 26,
+        buildTools        : '28.0.3',
+        compileSdk        : 28,
         espresso          : '2.2.2',
         exoplayer         : 'r2.5.4',
         isoparser         : '1.1.7',
         junit             : '4.12',
-        minSdk            : 17,
+        minSdk            : 21,
         publishVersion    : '1.0',
         publishVersionCode: 25,
-        supportLib        : '26.0.2',
+        supportLib        : '28.0.0',
         testRunner        : '0.5',
 ]


### PR DESCRIPTION
Fixed thumbnail inconsistency which presented the following problems:

* `getFameFromTime` method being not inaccurate given 2 different instances with the same millisecond
* Android Support version was old
* `seekTime` method being inaccurate when seeking time 